### PR TITLE
Add option to group samples in blocks

### DIFF
--- a/mlpp_lib/datasets.py
+++ b/mlpp_lib/datasets.py
@@ -38,6 +38,7 @@ class DataModule:
     group_samples: dict, optional
         Mapping of the form `{dim_name: group_size}` to indicate that the original order
         of the samples should be conserved for the `dim_name` dimension when stacking.
+        The dimension `dim_name` must be one of the batch dimensions in `batch_dims`.
         If `group_samples` is not None, NaNs are removed in blocks of size `group_size`.
     data_dir: string
         Path to the directory containing the raw data. Must be provided if features

--- a/mlpp_lib/losses.py
+++ b/mlpp_lib/losses.py
@@ -151,6 +151,7 @@ class WeightedCRPSEnergy(tf.keras.losses.Loss):
         self,
         y_true: Union[tf.Tensor, np.ndarray],
         y_pred: Union[tf.Tensor, np.ndarray, tfp.distributions.Distribution],
+        sample_weight=None,
     ) -> tf.Tensor:
         """
         Compute the loss.


### PR DESCRIPTION
- group samples in blocks of arbitrary size
- drop nans by block of samples
- shuffle blocks of samples
- use `DataLoader` in Keras' `fit()`
