### PR TITLE
Set batch num to 1 for low samples cases in the dataloader

### DIFF
--- a/mlpp_lib/datasets.py
+++ b/mlpp_lib/datasets.py
@@ -592,7 +592,7 @@ class DataLoader(tf.keras.utils.Sequence):
         self.shuffle = shuffle
         self.block_size = block_size
         self.num_samples = len(self.dataset.x)
-        self.num_batches = self.num_samples // batch_size
+        self.num_batches = self.num_samples // batch_size if batch_size <= self.num_samples else 1
         self._indices = tf.range(self.num_samples)
         self._seed = 0
         self._reset()


### PR DESCRIPTION
When creating a `DataLoader` with a `DataModule` that has less samples than the provided batch size, the `__getitem__` always returns an `IndexError`. This issues arises often when using thinning as the number of test and validation samples is already low.

The simple change consists in checking whether the number of samples is too low and in that case to set `batch_num` to be 1. This prevents the `__getitem__` from raising an `IndexError`.