### PR TITLE
Feature/scheduler

### DIFF
--- a/mlpp_lib/datasets.py
+++ b/mlpp_lib/datasets.py
@@ -592,7 +592,7 @@ class DataLoader(tf.keras.utils.Sequence):
         self.shuffle = shuffle
         self.block_size = block_size
         self.num_samples = len(self.dataset.x)
-        self.num_batches = self.num_samples // batch_size
+        self.num_batches = self.num_samples // batch_size if batch_size <= self.num_samples else 1
         self._indices = tf.range(self.num_samples)
         self._seed = 0
         self._reset()

--- a/mlpp_lib/train.py
+++ b/mlpp_lib/train.py
@@ -37,6 +37,13 @@ def get_log_params(param_run: dict) -> dict:
     return log_params
 
 
+def get_lr(optimizer: tf.keras.optimizers.Optimizer) -> float:
+    """Get the learning rate of the optimizer"""
+    def lr(y_true, y_pred):
+        return optimizer.lr
+    return lr
+
+
 def train(
     cfg: dict,
     datamodule: DataModule,
@@ -61,6 +68,7 @@ def train(
     loss = get_loss(loss_config)
     metrics = [get_metric(metric) for metric in cfg.get("metrics", [])]
     optimizer = get_optimizer(cfg.get("optimizer", "Adam"))
+    metrics.append(get_lr(optimizer))
     model.compile(optimizer=optimizer, loss=loss, metrics=metrics)
     model.summary(print_fn=LOGGER.info)
 

--- a/mlpp_lib/utils.py
+++ b/mlpp_lib/utils.py
@@ -128,7 +128,11 @@ def get_scheduler(scheduler_config: dict) -> tf.keras.optimizers.schedules.Learn
     if hasattr(tf.keras.optimizers.schedules, scheduler_name):
         LOGGER.info(f"Using keras built-in learning rate scheduler: {scheduler_name}")
         scheduler_obj = getattr(tf.keras.optimizers.schedules, scheduler_name)
-        scheduler = scheduler_obj(**scheduler_options)
+        scheduler = (
+            scheduler_obj(**scheduler_options)
+            if isinstance(scheduler_obj, type)
+            else scheduler_obj
+        )
     else:
         raise KeyError(f"The scheduler {scheduler_name} is not available.")
 

--- a/mlpp_lib/utils.py
+++ b/mlpp_lib/utils.py
@@ -116,7 +116,7 @@ def get_metric(metric: Union[str, dict]) -> Callable:
 
 
 def get_scheduler(
-    scheduler_config: Union[dict, str]
+    scheduler_config: Union[dict, None]
 ) -> Optional[tf.keras.optimizers.schedules.LearningRateSchedule]:
     """Create a learning rate scheduler from a config dictionary."""
 
@@ -129,12 +129,14 @@ def get_scheduler(
             "Scheduler configuration should contain exactly one scheduler name with its options."
         )
 
-    scheduler_name = list(scheduler_config.keys())[0]
+    scheduler_name = next(
+        iter(scheduler_config)
+    )  # first key is the name of the scheduler
     scheduler_options = scheduler_config[scheduler_name]
 
     if not isinstance(scheduler_options, dict):
         raise ValueError(
-            f"Scheduler options for {scheduler_name} should be a dictionary."
+            f"Scheduler options for '{scheduler_name}' should be a dictionary."
         )
 
     if hasattr(tf.keras.optimizers.schedules, scheduler_name):
@@ -155,8 +157,7 @@ def get_optimizer(optimizer: Union[str, dict]) -> Callable:
     if isinstance(optimizer, dict):
         optimizer_name = list(optimizer.keys())[0]
         optimizer_options = optimizer[optimizer_name]
-        scheduler = get_scheduler(optimizer_options.pop("learning_rate", None))
-        if scheduler:
+        if scheduler := get_scheduler(optimizer_options.pop("learning_rate", None)):
             optimizer_options["learning_rate"] = scheduler
     else:
         optimizer_name = optimizer

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -44,6 +44,34 @@ RUNS = [
         "optimizer": {"Adam": {"learning_rate": 0.1, "beta_1": 0.95}},
         "metrics": ["bias", "mean_absolute_error", {"MAEBusts": {"threshold": 0.5}}],
     },
+    # use a learning rate scheduler
+    {
+        "features": ["coe:x1"],
+        "targets": ["obs:y1"],
+        "model": {
+            "fully_connected_network": {
+                "hidden_layers": [10],
+                "probabilistic_layer": "IndependentNormal",
+            }
+        },
+        "loss": "crps_energy",
+        "optimizer": {
+            "Adam": {
+                "learning_rate": {
+                    "CosineDecayRestarts": {
+                        "initial_learning_rate": 0.001,
+                        "first_decay_steps": 20,
+                        "t_mul": 1.5,
+                        "m_mul": 1.1,
+                        "alpha": 0,
+                    }
+                }
+            }
+        },
+        "callbacks": [
+            {"EarlyStopping": {"patience": 10, "restore_best_weights": True}}
+        ],
+    },
     #
     {
         "features": ["coe:x1"],


### PR DESCRIPTION
In order to allow the use of Keras schedulers, this PR adapts the train and utils to let the user choose (or not) a scheduler.
A new metric is also added to print the `lr` at each epoch.