### PR TITLE
Change num_batches definition

### DIFF
--- a/mlpp_lib/datasets.py
+++ b/mlpp_lib/datasets.py
@@ -596,9 +596,7 @@ class DataLoader(tf.keras.utils.Sequence):
         self.shuffle = shuffle
         self.block_size = block_size
         self.num_samples = len(self.dataset.x)
-        self.num_batches = (
-            self.num_samples // batch_size if batch_size <= self.num_samples else 1
-        )
+        self.num_batches = int(np.ceil(self.num_samples / batch_size))
         self._indices = tf.range(self.num_samples)
         self._seed = 0
         self._reset()


### PR DESCRIPTION
With the current implementation, we do not pass the whole dataset as long as its length is not a multiple of the batch size. With this small change we can pass a final batch (uncomplete) to the network.
This ensure that we see the whole validation dataset at least